### PR TITLE
Change layer name for 3.9 to psycopg2-py39

### DIFF
--- a/3.9/serverless.yml
+++ b/3.9/serverless.yml
@@ -8,7 +8,7 @@ provider:
   stage: prod
 
 layers:
-  psycopg2-py38:
+  psycopg2-py39:
     description: "psycopg2 python postgresql client library."
     buildScript: ./build.sh
     path: layer


### PR DESCRIPTION
Seems like a typo, layer for 3.9 was named psycopg2-py38