### PR TITLE
Switch to AWS Lambda Python 3.9 image

### DIFF
--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.9
+FROM public.ecr.aws/lambda/python:3.9
 
 RUN pip install -t /opt/python/ psycopg2-binary
 


### PR DESCRIPTION
The prior image is not available to build with.